### PR TITLE
Users Controller 에 AuthGuard 적용

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -35,14 +35,14 @@ import { UsersModule } from './users/users.module';
   ],
   controllers: [AppController],
   providers: [
-    // {
-    //   provide: APP_INTERCEPTOR,
-    //   useClass: ResponseInterceptor,
-    // },
-    // {
-    //   provide: APP_FILTER,
-    //   useClass: AllExceptionsFilter,
-    // },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ResponseInterceptor,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: AllExceptionsFilter,
+    },
     AppService,
   ],
 })

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -35,14 +35,14 @@ import { UsersModule } from './users/users.module';
   ],
   controllers: [AppController],
   providers: [
-    {
-      provide: APP_INTERCEPTOR,
-      useClass: ResponseInterceptor,
-    },
-    {
-      provide: APP_FILTER,
-      useClass: AllExceptionsFilter,
-    },
+    // {
+    //   provide: APP_INTERCEPTOR,
+    //   useClass: ResponseInterceptor,
+    // },
+    // {
+    //   provide: APP_FILTER,
+    //   useClass: AllExceptionsFilter,
+    // },
     AppService,
   ],
 })

--- a/backend/src/posts/posts-category.controller.ts
+++ b/backend/src/posts/posts-category.controller.ts
@@ -71,7 +71,9 @@ export class PostsCategoryController {
     description: '게시글 종류 삭제 성공',
   })
   @Delete('/:id')
-  deletePostCategory(@Param('id', ParseIntPipe) id: number): void {
-    this.postsCategoryService.deletePostCategory(id);
+  async deletePostCategory(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<void> {
+    await this.postsCategoryService.deletePostCategory(id);
   }
 }

--- a/backend/src/posts/posts.module.ts
+++ b/backend/src/posts/posts.module.ts
@@ -6,9 +6,10 @@ import { Post } from './entities/post.entity';
 import { PostsCategoryService } from './posts-category.service';
 import { PostsCategoryController } from './posts-category.controller';
 import { PostCategory } from './entities/post-category.entity';
+import { User } from '../users/entities/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, PostCategory])],
+  imports: [TypeOrmModule.forFeature([Post, PostCategory, User])],
   controllers: [PostsCategoryController, PostsController],
   providers: [PostsService, PostsCategoryService],
 })

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -7,11 +7,13 @@ import {
   Param,
   Delete,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from './entities/user.entity';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('users')
 @ApiTags('Users API')
@@ -35,6 +37,7 @@ export class UsersController {
   @Delete(':id')
   @ApiOperation({ summary: '유저 삭제 API', description: '유저를 삭제합니다.' })
   @ApiCreatedResponse({ description: '유저를 삭제합니다.', type: null })
+  @UseGuards(AuthGuard('jwt'))
   removeUserById(@Param('id', ParseIntPipe) id: number): Promise<void> {
     return this.usersService.removeUserById(id);
   }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -14,7 +14,12 @@ import {
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
-import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiCookieAuth,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { User } from './entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { GetCurrentUserId } from '../commons/decorators/get.current-userId.decorator';
@@ -42,6 +47,8 @@ export class UsersController {
   @Delete(':id')
   @ApiOperation({ summary: '유저 삭제 API', description: '유저를 삭제합니다.' })
   @ApiCreatedResponse({ description: '유저를 삭제합니다.', type: null })
+  @ApiCookieAuth('refreshToken')
+  @ApiCookieAuth('accessToken')
   @UseGuards(AuthGuard('jwt'))
   removeUserById(
     @Param('id', ParseIntPipe) id: number,

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -11,6 +11,7 @@ import {
   UnauthorizedException,
   Redirect,
   Res,
+  ForbiddenException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -59,8 +60,12 @@ export class UsersController {
       throw new UnauthorizedException();
     }
 
-    res.clearCookie('AccessToken');
-    res.clearCookie('RefreshToken');
+    try {
+      res.clearCookie('AccessToken');
+      res.clearCookie('RefreshToken');
+    } catch (error) {
+      throw new ForbiddenException('Cookie access 실패');
+    }
 
     return this.usersService.removeUserById(id);
   }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -8,12 +8,17 @@ import {
   Delete,
   ParseIntPipe,
   UseGuards,
+  UnauthorizedException,
+  Redirect,
+  Res,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { User } from './entities/user.entity';
 import { AuthGuard } from '@nestjs/passport';
+import { GetCurrentUserId } from '../commons/decorators/get.current-userId.decorator';
+import { Response } from 'express';
 
 @Controller('users')
 @ApiTags('Users API')
@@ -38,7 +43,18 @@ export class UsersController {
   @ApiOperation({ summary: '유저 삭제 API', description: '유저를 삭제합니다.' })
   @ApiCreatedResponse({ description: '유저를 삭제합니다.', type: null })
   @UseGuards(AuthGuard('jwt'))
-  removeUserById(@Param('id', ParseIntPipe) id: number): Promise<void> {
+  removeUserById(
+    @Param('id', ParseIntPipe) id: number,
+    @GetCurrentUserId() currentUserId: number,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    if (id !== currentUserId) {
+      throw new UnauthorizedException();
+    }
+
+    res.clearCookie('AccessToken');
+    res.clearCookie('RefreshToken');
+
     return this.usersService.removeUserById(id);
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,9 +3,11 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { AuthModule } from '../auth/auth.module';
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), AuthModule, RedisModule],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -9,11 +9,15 @@ import * as bcrypt from 'bcrypt';
 
 import { CreateUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
+import { AuthService } from '../auth/auth.service';
+import { RedisService } from '../redis/redis.service';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
+    private authService: AuthService,
+    private readonly redisService: RedisService,
   ) {}
 
   async createUser(createUserDto: CreateUserDto): Promise<User> {
@@ -53,6 +57,8 @@ export class UsersService {
     }
 
     user.isDeleted = true;
+    await this.authService.logout(id);
     await this.userRepository.save(user);
+    await this.redisService.delKey('refresh' + id.toString());
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -17,7 +17,7 @@ export class UsersService {
   constructor(
     @InjectRepository(User) private userRepository: Repository<User>,
     private authService: AuthService,
-    private readonly redisService: RedisService,
+    private redisService: RedisService,
   ) {}
 
   async createUser(createUserDto: CreateUserDto): Promise<User> {


### PR DESCRIPTION
# Topic

Users Controller 에 AuthGuard 적용

## Description

- delete user controller에 AuthGuard 적용 (feature)
- delete user 시 쿠키 클리어 (fix)

## Output

feat: user DELETE API 에 AuthGuard 추가
fix: delete user 시 cookie 제거되지 않던 문제 해결
fix: interceptor, filter 주석 해제
fix: clearCookie try-catch 적용
fix: redisService에서 readonly 제거